### PR TITLE
Prevent CSS from applying to all table cells

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@
     color: red;
 }
 
-.mod_groupselect .edit, .text_to_html, td {
+.mod_groupselect .edit, .mod_groupselect .text_to_html, .mod_groupselect td {
   /*word-wrap:break-word !important;*/
   word-break: break-all !important;
 }


### PR DESCRIPTION
Hi there, the CSS rule for changing the word-break is applying to all <td> elements on the page, even if they aren't related to groupselect. This can break themes and shouldn't really happen.

The patch localises the rules to within the groupselect HTML and prevents the styling leaking out into unexpected places. Hope it's useful!

Cheers, Michael.
